### PR TITLE
Fix: Preserve bold formatting within page links

### DIFF
--- a/lib/tiptap-extensions/page-link.ts
+++ b/lib/tiptap-extensions/page-link.ts
@@ -220,24 +220,30 @@ const existencePlugin = new Plugin<Map<string, string | null>>({
 							// 設定済みリンク（pageIdがある場合）にdata-page-id属性を設定
 							...(pageId && !isExternal ? { "data-page-id": pageId } : {}),
 						};
-						if (start >= paraStart && end <= paraEnd) {
-							decos.push(Decoration.inline(start, end, decoAttrs));
-						} else {
-							decos.push(
-								Decoration.inline(start, start + 1, { style: "display: none" }),
-							);
-							decos.push(
-								Decoration.inline(end - 1, end, { style: "display: none" }),
-							);
-							const inactiveAttrs: Record<string, string> = {
-								...decoAttrs,
-								contentEditable: "false",
-							};
+						const isActive = start >= paraStart && end <= paraEnd;
+
+						// 常にブラケットを非表示にするデコレーションを適用
+						decos.push(
+							Decoration.inline(start, start + 1, { style: "display: none" }),
+						);
+						decos.push(
+							Decoration.inline(end - 1, end, { style: "display: none" }),
+						);
+
+						// リンク内容のデコレーション属性を準備
+						const linkContentAttrs: Record<string, string | boolean> = {
+							...decoAttrs,
+						};
+
+						if (!isActive) {
+							linkContentAttrs.contentEditable = "false";
 							if (!isExternal && !pageId) {
-								inactiveAttrs["data-page-title"] = title;
+								linkContentAttrs["data-page-title"] = title;
 							}
-							decos.push(Decoration.inline(start + 1, end - 1, inactiveAttrs));
 						}
+
+						// リンク内容にデコレーションを適用
+						decos.push(Decoration.inline(start + 1, end - 1, linkContentAttrs));
 					}
 				}
 				// Decorate tag links (#text)


### PR DESCRIPTION
Refactors the Tiptap page link extension to ensure that bold formatting (and other marks) within a `[[page link]]` is preserved.

Previously, the decoration logic for the active paragraph would wrap the entire `[[link]]` string in a single `<a>` tag, which would strip any nested formatting.

The new implementation unifies the logic for active and inactive paragraphs. It now always applies separate decorations:
- One to hide the opening `[[`
- One to hide the closing `]]`
- One to wrap the inner content in an `<a>` tag

This allows the inner content to retain its own formatting marks, such as `<strong>`, while still functioning as a link.